### PR TITLE
specification: only warns instead of raise DeprecationWarning

### DIFF
--- a/pamqp/specification.py
+++ b/pamqp/specification.py
@@ -5,9 +5,10 @@ Auto-generated AMQP Support Module
 WARNING: DO NOT EDIT. To Generate run tools/codegen.py
 
 """
-__since__ = '2018-09-11'
+__since__ = '2018-12-27'
 
 import struct
+import warnings
 
 from pamqp import decode
 from pamqp import encode
@@ -2610,14 +2611,15 @@ class Basic(object):
 
             :param bool requeue: Requeue the message
 
-            :raises: DeprecationWarning
+            .. deprecated:: 0-9-1
+            This command is deprecated in AMQP 0-9-1
 
             """
             # Requeue the message
             self.requeue = requeue
 
             # This command is deprecated in AMQP 0-9-1
-            raise DeprecationWarning(DEPRECATION_WARNING)
+            warnings.warn(DEPRECATION_WARNING, category=DeprecationWarning)
 
     class Recover(Frame):
         """Redeliver unacknowledged messages

--- a/tests/test_frame_unmarshaling.py
+++ b/tests/test_frame_unmarshaling.py
@@ -463,7 +463,24 @@ class DemarshalingTests(unittest.TestCase):
 
     def test_basic_recoverasync(self):
         frame_data = b'\x01\x00\x01\x00\x00\x00\x05\x00<\x00d\x00\xce'
-        self.assertRaises(DeprecationWarning, frame.unmarshal, frame_data)
+        expectation = {'requeue': False}
+
+        # Decode the frame and validate lengths
+        consumed, channel, frame_obj = frame.unmarshal(frame_data)
+        self.assertEqual(consumed, 13,
+                         'Bytes consumed did not match expectation: %i, %i' %
+                         (consumed, 13))
+
+        self.assertEqual(channel, 1,
+                         'Channel number did not match expectation: %i, %i' %
+                         (channel, 1))
+
+        # Validate the frame name
+        self.assertEqual(frame_obj.name, 'Basic.RecoverAsync',
+                         ('Frame was of wrong type, expected Basic.RecoverAsync, '
+                          'received %s' % frame_obj.name))
+
+        self.assertDictEqual(dict(frame_obj), expectation)
 
     def test_basic_recoverok(self):
         frame_data = b'\x01\x00\x01\x00\x00\x00\x04\x00<\x00o\xce'

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from pamqp import specification
 
@@ -908,7 +909,14 @@ class AttributeInMethodTests(unittest.TestCase):
 
 class DeprecationWarningTests(unittest.TestCase):
     def test_basic_recoverasync_raises_deprecation_error(self):
-        self.assertRaises(DeprecationWarning, specification.Basic.RecoverAsync)
+        with warnings.catch_warnings(record=True) as warning:
+            warnings.simplefilter("always")
+            specification.Basic.RecoverAsync()
+            self.assertEqual(warning[0].category, DeprecationWarning)
+            self.assertEqual(
+                'This command is deprecated in AMQP 0-9-1',
+                 str(warning[0].message)
+            )
 
 
 class BasicPropertiesTests(unittest.TestCase):

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -321,6 +321,7 @@ WARNING: DO NOT EDIT. To Generate run tools/codegen.py
 __since__ = '%s'
 
 import struct
+import warnings
 
 from pamqp import decode
 from pamqp import encode
@@ -390,10 +391,12 @@ new_line()
 
 comment("Other constants")
 # Deprecation Warning
-DEPRECATION_WARNING = 'This command is deprecated in AMQP %s' % \
-                        ('-'.join([str(amqp['major-version']),
-                                   str(amqp['minor-version']),
-                                   str(amqp['revision'])]))
+
+AMQP_VERSION = ('-'.join([str(amqp['major-version']),
+           str(amqp['minor-version']),
+           str(amqp['revision'])]))
+DEPRECATION_WARNING = 'This command is deprecated in AMQP %s' % AMQP_VERSION
+
 new_line('DEPRECATION_WARNING = \'%s\'' % DEPRECATION_WARNING)
 new_line()
 
@@ -620,7 +623,8 @@ for class_name in class_list:
                method_xml[0].attrib['deprecated']:
                 deprecated = True
                 new_line()
-                new_line(':raises: DeprecationWarning', indent)
+                new_line('.. deprecated:: %s' % AMQP_VERSION, indent)
+                new_line(DEPRECATION_WARNING, indent)
             else:
                 deprecated = False
 
@@ -651,7 +655,8 @@ for class_name in class_list:
             # Check if we're deprecated and warn if so
             if deprecated:
                 comment(DEPRECATION_WARNING, indent)
-                new_line('raise DeprecationWarning(DEPRECATION_WARNING)', indent)
+                new_line('warnings.warn(DEPRECATION_WARNING,'
+                         ' category=DeprecationWarning)', indent)
                 new_line()
 
             # End of function


### PR DESCRIPTION
Updates codegen tool to mention the method as deprecated,
instead of hardly raise a DeprecationWarning