### PR TITLE
Exposing frame_parts method

### DIFF
--- a/pamqp/frame.py
+++ b/pamqp/frame.py
@@ -48,7 +48,7 @@ def unmarshal(data_in):
         raise exceptions.UnmarshalingException(header.ProtocolHeader, error)
 
     # Decode the low level frame and break it into parts
-    frame_type, channel_id, frame_size = _frame_parts(data_in)
+    frame_type, channel_id, frame_size = frame_parts(data_in)
 
     # Heartbeats do not have frame length indicators
     if frame_type == specification.FRAME_HEARTBEAT and frame_size == 0:
@@ -180,7 +180,7 @@ def _unmarshal_body_frame(frame_data):
     return content_body
 
 
-def _frame_parts(data_in):
+def frame_parts(data_in):
     """Try and decode a low-level AMQP frame and return the parts of the frame.
 
     :param bytes data_in: Raw byte stream data


### PR DESCRIPTION
For my [asynchronous amqp driver](https://github.com/mosquito/aiormq) is useful has method for parse first bytes of incomming frame. [Here](https://github.com/mosquito/aiormq/blob/b33ffcb3393e0e52d9e8f6ed416a5e914c1e635a/aiormq/connection.py#L301) I have to import it with underscore.