### PR TITLE
Add type explicitly for encode.table_integer()

### DIFF
--- a/pamqp/decode.py
+++ b/pamqp/decode.py
@@ -11,6 +11,9 @@ import struct
 import time
 
 from pamqp import PYTHON3
+from pamqp.types import (
+    LongInt, LongLongInt, LongUInt, ShortInt, ShortUInt, ShortShortInt
+)
 
 
 class Struct(object):
@@ -126,7 +129,7 @@ def long_int(value):
 
     """
     try:
-        return 4, Struct.long.unpack(value[0:4])[0]
+        return 4, LongInt(Struct.long.unpack(value[0:4])[0])
     except TypeError:
         raise ValueError('Could not unpack data')
 
@@ -140,7 +143,7 @@ def long_uint(value):
 
     """
     try:
-        return 4, Struct.ulong.unpack(value[0:4])[0]
+        return 4, LongUInt(Struct.ulong.unpack(value[0:4])[0])
     except TypeError:
         raise ValueError('Could not unpack data')
 
@@ -154,7 +157,7 @@ def long_long_int(value):
 
     """
     try:
-        return 8, struct.unpack('>q', value[0:8])[0]
+        return 8, LongLongInt(struct.unpack('>q', value[0:8])[0])
     except TypeError:
         raise ValueError('Could not unpack data')
 
@@ -197,7 +200,7 @@ def short_int(value):
 
     """
     try:
-        return 2, Struct.short.unpack_from(value[0:2])[0]
+        return 2, ShortInt(Struct.short.unpack_from(value[0:2])[0])
     except TypeError:
         raise ValueError('Could not unpack data')
 
@@ -211,7 +214,7 @@ def short_uint(value):
 
     """
     try:
-        return 2, Struct.ushort.unpack_from(value[0:2])[0]
+        return 2, ShortUInt(Struct.ushort.unpack_from(value[0:2])[0])
     except TypeError:
         raise ValueError('Could not unpack data')
 
@@ -225,7 +228,7 @@ def short_short_int(value):
 
     """
     try:
-        return 1, Struct.short_short.unpack_from(value[0:1])[0]
+        return 1, ShortShortInt(Struct.short_short.unpack_from(value[0:1])[0])
     except TypeError:
         raise ValueError('Could not unpack data')
 

--- a/pamqp/encode.py
+++ b/pamqp/encode.py
@@ -14,6 +14,9 @@ import struct
 import time
 
 from pamqp import PYTHON3
+from pamqp.types import (
+    LongInt, LongLongInt, LongUInt, ShortInt, ShortUInt
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -316,16 +319,29 @@ def table_integer(value):
 
     """
     # Send the appropriately sized data value
-    if -32768 <= value <= 32767:
+    if type(value) in (int, long):
+        if ShortInt.validate(value):
+            value = ShortInt(value)
+        elif ShortUInt.validate(value):
+            value = ShortUInt(value)
+        elif LongInt.validate(value):
+            value = LongInt(value)
+        elif LongUInt.validate(value):
+            value = LongUInt(value)
+        elif LongLongInt.validate(value):
+            value = LongLongInt(value)
+
+    if isinstance(value, ShortInt):
         return b's' + short_int(value)
-    elif 0 <= value <= 65535:
+    elif isinstance(value, ShortUInt):
         return b'u' + short_uint(value)
-    elif -2147483648 < value < 2147483647:
+    elif isinstance(value, LongInt):
         return b'I' + long_int(value)
-    elif 0 <= value <= 4294967295:
+    elif isinstance(value, LongUInt):
         return b'i' + long_uint(value)
-    elif -9223372036854775808 < value < 9223372036854775807:
+    elif isinstance(value, LongLongInt):
         return b'l' + long_long_int(value)
+
     raise TypeError("Unsupported numeric value: %r" % value)
 
 

--- a/pamqp/types.py
+++ b/pamqp/types.py
@@ -1,0 +1,56 @@
+class IntBase(int):
+    MIN = None
+    MAX = None
+
+    @classmethod
+    def validate(cls, value):
+        return cls.MIN <= value <= cls.MAX
+
+    def __new__(cls, value):
+        if not cls.validate(value):
+            raise ValueError()
+
+        return super(IntBase, cls).__new__(cls, value)
+
+    def __repr__(self):
+        return "<%s: %d>" % (self.__class__.__name__, self)
+
+
+class ShortShortInt(IntBase):
+    MIN = 0
+    MAX = 255
+
+
+class ShortInt(IntBase):
+    MIN = -32768
+    MAX = 32767
+
+
+class ShortUInt(IntBase):
+    MIN = 0
+    MAX = 65535
+
+
+class LongInt(IntBase):
+    MIN = -2147483648
+    MAX = 2147483647
+
+
+class LongUInt(IntBase):
+    MIN = 0
+    MAX = 4294967295
+
+
+class LongLongInt(IntBase):
+    MIN = -9223372036854775808
+    MAX = 9223372036854775807
+
+
+__all__ = (
+    'LongInt',
+    'LongLongInt',
+    'LongUInt',
+    'ShortInt',
+    'ShortShortInt',
+    'ShortUInt',
+)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from decimal import Decimal
 import unittest
 
-from pamqp import encode, PYTHON3
+from pamqp import encode, PYTHON3, types
 
 if PYTHON3:
     long = int
@@ -351,3 +351,19 @@ class MarshalingTests(unittest.TestCase):
 
     def test_encode_by_type_error(self):
         self.assertRaises(TypeError, encode.by_type, 12345.12434, 'foo')
+
+    def test_explicit_table_integer(self):
+        cases = (
+            [types.ShortInt, encode.short_int, -120],
+            [types.ShortUInt, encode.short_uint, 120],
+            [types.LongInt, encode.long_int, 120],
+            [types.LongUInt, encode.long_uint, 120],
+            [types.LongLongInt, encode.long_long_int, -12345678],
+        )
+
+        for cls, validator, value in cases:
+            with self.subTest("%r" % cls):
+                self.assertEqual(
+                    encode.table_integer(cls(value))[1:],
+                    validator(value)
+                )

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -362,8 +362,8 @@ class MarshalingTests(unittest.TestCase):
         )
 
         for cls, validator, value in cases:
-            with self.subTest("%r" % cls):
-                self.assertEqual(
-                    encode.table_integer(cls(value))[1:],
-                    validator(value)
-                )
+            self.assertEqual(
+                encode.table_integer(cls(value))[1:],
+                validator(value),
+                "Invalid value for %r" % cls,
+            )


### PR DESCRIPTION
My vision of explicit type passing to `encode.table_integer()`.

Fixes for (https://github.com/mosquito/aio-pika/issues/197#issuecomment-467797053)