### PR TITLE
Add 'py.typed' for PEP 561 compat

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+include pamqp/py.typed


### PR DESCRIPTION
This tells mypy to use the type annotations in pamqp's code when checking some other code that uses pamqp.

Helpful links:
- https://www.python.org/dev/peps/pep-0561/
- https://mypy.readthedocs.io/en/latest/installed_packages.html
- https://github.com/python/mypy/issues/3498#issuecomment-382093539