### PR TITLE
Fix Reject not allowing requeue being set to False

### DIFF
--- a/pamqp/commands.py
+++ b/pamqp/commands.py
@@ -2434,7 +2434,7 @@ class Basic:
                      requeue: bool = True) -> None:
             """Initialize the :class:`Basic.Reject` class"""
             self.delivery_tag = delivery_tag
-            self.requeue = requeue or True
+            self.requeue = requeue
 
     class RecoverAsync(base.Frame):
         """Redeliver unacknowledged messages


### PR DESCRIPTION
It's currently not possible to set requeue to `False`. This is because `requeue or True` will always result in `True`.