### PR TITLE
Used unsigned byte, not signed byte

### DIFF
--- a/pamqp/decode.py
+++ b/pamqp/decode.py
@@ -322,7 +322,7 @@ def _embedded_value(value):
     # Determine the field type and encode it
     if value[0:1] == b't':
         bytes_consumed, value = boolean(value[1:])
-    elif value[0:1] == b'b':
+    elif value[0:1] == b'B':
         bytes_consumed, value = short_short_int(value[1:])
     elif value[0:1] == b's':
         bytes_consumed, value = short_int(value[1:])

--- a/pamqp/encode.py
+++ b/pamqp/encode.py
@@ -337,7 +337,7 @@ def table_integer(value):
 
     # Send the appropriately sized data value
     if 0 <= value <= 255:
-        return b'b' + octet(value)
+        return b'B' + octet(value)
     elif -32768 <= value <= 32767:
         return b's' + short_int(value)
     elif 0 <= value <= 65535:
@@ -362,7 +362,7 @@ def _deprecated_table_integer(value):
     """
     # Send the appropriately sized data value
     if 0 <= value <= 255:
-        return b'b' + octet(value)
+        return b'B' + octet(value)
     elif -32768 <= value <= 32767:
         return b's' + short_int(value)
     elif -2147483648 <= value <= 2147483647:

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -111,7 +111,7 @@ class CodecDecodeTests(unittest.TestCase):
         self.assertRaises(ValueError, decode.decimal, False)
 
     def test_decode_double_value(self):
-        value = b'@\t!\xf9\xf0\x1b\x86n'
+        value = b'@\t!\xf9\xf0\x1B\x86n'
         self.assertEqual(round(decode.double(value)[1], 5),
                          round(float(3.14159), 5))
 
@@ -641,13 +641,13 @@ class CodecDecodeTests(unittest.TestCase):
         self.assertEqual(decode._embedded_value(value)[0], 3)
 
     def test_decode_embedded_value_short_short_bytes_consumed(self):
-        self.assertEqual(decode._embedded_value(b'b\xff')[0], 2)
+        self.assertEqual(decode._embedded_value(b'B\xff')[0], 2)
 
     def test_decode_embedded_value_short_short_data_type(self):
-        self.assertIsInstance(decode._embedded_value(b'b\xff')[1], int)
+        self.assertIsInstance(decode._embedded_value(b'B\xff')[1], int)
 
     def test_decode_embedded_value_short_short_value(self):
-        self.assertEqual(decode._embedded_value(b'b\xff')[1], 255)
+        self.assertEqual(decode._embedded_value(b'B\xff')[1], 255)
 
     def test_decode_embedded_value_short_data_type(self):
         value = b's\x7f\xff'

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -162,8 +162,8 @@ class MarshalingTests(unittest.TestCase):
         self.assertRaises(TypeError, encode.timestamp, 'hi')
 
     def test_encode_field_array(self):
-        expectation = (b'\x00\x00\x00:b\x01u\xaf\xc8I\x02bZ\x00S\x00\x00\x00'
-                       b'\x04TestT\x00\x00\x00\x00Ec)\x92I\xbb\x9a\xca\x00D'
+        expectation = (b'\x00\x00\x00:B\x01u\xaf\xc8I\x02bZ\x00S\x00\x00\x00'
+                       b'\x04TestT\x00\x00\x00\x00Ec)\x92I\xbB\x9a\xca\x00D'
                        b'\x02\x00\x00\x01:f@H\xf5\xc3i\xc4e5\xffl\x80\x00\x00'
                        b'\x00\x00\x00\x00\x08')
         data = [
@@ -188,11 +188,11 @@ class MarshalingTests(unittest.TestCase):
                           {'key': encode.field_table})
 
     def test_encode_field_table(self):
-        expectation = (b"\x00\x00\x04'\x08arrayvalA\x00\x00\x00\x06b\x01b"
-                       b'\x02b\x03\x07boolvalt\x01\tbytearrayx\x00\x00\x00'
+        expectation = (b"\x00\x00\x04'\x08arrayvalA\x00\x00\x00\x06B\x01B"
+                       b'\x02B\x03\x07boolvalt\x01\tbytearrayx\x00\x00\x00'
                        b'\x03AAA\x06decvalD\x02\x00\x00\x01:\x07dictvalF\x00'
                        b'\x00\x00\x0c\x03fooS\x00\x00\x00\x03bar\x08floatval'
-                       b'f@H\xf5\xc3\x06intvalb\x01\x07longstrS\x00\x00\x03t'
+                       b'f@H\xf5\xc3\x06intvalB\x01\x07longstrS\x00\x00\x03t'
                        b'000000000000000000000000000000000000000000000000000'
                        b'011111111111111111111111111111111111111111111111111'
                        b'112222222222222222222222222222222222222222222222222'
@@ -250,8 +250,8 @@ class MarshalingTests(unittest.TestCase):
         self.assertEqual(encode.field_table(data), expectation)
 
     def test_encode_by_type_field_array(self):
-        expectation = (b'\x00\x00\x008b\x01sBhu\xaf\xc8S\x00\x00\x00\x04TestT'
-                       b'\x00\x00\x00\x00Ec)\x92I\xbb\x9a\xca\x00D\x02\x00'
+        expectation = (b'\x00\x00\x008B\x01sBhu\xaf\xc8S\x00\x00\x00\x04TestT'
+                       b'\x00\x00\x00\x00Ec)\x92I\xbB\x9a\xca\x00D\x02\x00'
                        b'\x00\x01:f@H\xf5\xc3i\xc4e5\xffl\x80\x00\x00\x00\x00'
                        b'\x00\x00\x08')
         data = [
@@ -297,7 +297,7 @@ class MarshalingTests(unittest.TestCase):
             b'\x00\x00\x00\x00Ec)\x92')
 
     def test_encode_by_type_field_table(self):
-        expectation = (b'\x00\x00\x04B\x08arrayvalA\x00\x00\x00\x08b\x01s\x10'
+        expectation = (b'\x00\x00\x04B\x08arrayvalA\x00\x00\x00\x08B\x01s\x10'
                        b'`u\xa4\x10\x07boolvalt\x01\x06decvalD\x02\x00\x00\x01'
                        b':\x07dictvalF\x00\x00\x00\x0c\x03fooS\x00\x00\x00\x03'
                        b'bar\x08floatvalf@H\xf5\xc3\x07longstrS\x00\x00\x03t00'
@@ -321,7 +321,7 @@ class MarshalingTests(unittest.TestCase):
                        b'\x06s32intI\xc4e6\x00\x06s64intl7\x82\xda\xce\x9d\x90'
                        b'\x00\x00\x06strvalS\x00\x00\x00\x04Test\x0ctimestamp'
                        b'valT\x00\x00\x00\x00Ec)\x92\x06u16ints \x00\x06u32int'
-                       b'i\xeek(\x00\x05u8bitb ')
+                       b'i\xeek(\x00\x05u8bitB ')
         data = {
             'u8bit': 32,
             'u16int': 8192,
@@ -374,7 +374,7 @@ class EncodeTableIntegerTestCase(unittest.TestCase):
 
     def test_table_integer(self):
         tests = {
-            'short-short': (32, b'b '),
+            'short-short': (32, b'B '),
             'short': (1024, b's\x04\x00'),
             'short-negative': (-1024, b's\xfc\x00'),
             'short-unsigned': (32768, b'u\x80\x00'),
@@ -392,7 +392,7 @@ class EncodeTableIntegerTestCase(unittest.TestCase):
 
     def test_deprecated_table_integer(self):
         tests = {
-            'short-short': (32, b'b '),
+            'short-short': (32, b'B '),
             'short': (1024, b's\x04\x00'),
             'short-negative': (-1024, b's\xfc\x00'),
             'long': (65536, b'I\x00\x01\x00\x00'),


### PR DESCRIPTION
This patch addresses #27 for Python 2.X builds.