### PR TITLE
Add support for timestamps with millisecond precision

### DIFF
--- a/pamqp/decode.py
+++ b/pamqp/decode.py
@@ -5,6 +5,7 @@ Functions for decoding data of various types including field tables and arrays
 """
 import datetime
 import decimal as _decimal
+import math
 import time
 import typing
 
@@ -262,8 +263,15 @@ def timestamp(value: bytes) -> typing.Tuple[int, datetime.datetime]:
     """
     try:
         temp = common.Struct.timestamp.unpack(value[0:8])
+        ts = temp[0]
+
+        # Test whether this is a timestamp with millisecond precision
+        digits = int(math.log10(ts)) + 1
+        if digits >= 13:
+            ts = int(ts / 1000)
+
         return 8, datetime.datetime.fromtimestamp(
-            time.mktime(time.gmtime(temp[0])))
+            time.mktime(time.gmtime(ts)))
     except TypeError:
         raise ValueError('Could not unpack timestamp value')
 

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -240,6 +240,10 @@ class CodecDecodeTests(unittest.TestCase):
     def test_decode_timestamp_bytes_consumed(self):
         self.assertEqual(decode.timestamp(b'\x00\x00\x00\x00Ec)\x92')[0], 8)
 
+    def test_decode_timestamp_milliseconds(self):
+        self.assertIsInstance(
+            decode.timestamp(b'\x00\x00\x01w\xf7\xdb\xcfg')[1], datetime.datetime)
+
     def test_decode_timestamp_data_type(self):
         self.assertIsInstance(
             decode.timestamp(b'\x00\x00\x00\x00Ec)\x92')[1], datetime.datetime)


### PR DESCRIPTION
I was using aio-pika with the Ably AMQP integration and getting consistent errors decoding message timestamps coming from Ably.

turns out they are sending timestamps with millisecond precision which chokes the decoder. This PR tests whether a timestamp has 13 or more digits after the initial decoding op and divides by 1000 if that is the case. This fixed the issue i was having