### PR TITLE
Fix DST/TZ issues on timestamp properties

### DIFF
--- a/pamqp/decode.py
+++ b/pamqp/decode.py
@@ -5,7 +5,6 @@ Functions for decoding data of various types including field tables and arrays
 """
 import datetime
 import decimal as _decimal
-import time
 import typing
 
 from pamqp import common
@@ -262,8 +261,7 @@ def timestamp(value: bytes) -> typing.Tuple[int, datetime.datetime]:
     """
     try:
         temp = common.Struct.timestamp.unpack(value[0:8])
-        return 8, datetime.datetime.fromtimestamp(
-            time.mktime(time.gmtime(temp[0])))
+        return 8, datetime.datetime.utcfromtimestamp(temp[0])
     except TypeError:
         raise ValueError('Could not unpack timestamp value')
 

--- a/pamqp/encode.py
+++ b/pamqp/encode.py
@@ -244,7 +244,10 @@ def timestamp(value: typing.Union[datetime.datetime, time.struct_time]) \
 
     """
     if isinstance(value, datetime.datetime):
-        value = value.timetuple()
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            # assume datetime object is UTC
+            value = value.replace(tzinfo=datetime.timezone.utc)
+        return common.Struct.timestamp.pack(int(value.timestamp()))
     if isinstance(value, time.struct_time):
         return common.Struct.timestamp.pack(calendar.timegm(value))
     raise TypeError(

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+import datetime
 import unittest
 
 from pamqp import decode, encode
@@ -14,3 +15,11 @@ class EncodeDecodeTests(unittest.TestCase):
         encoded = encode.field_table(data)
         decoded = decode.field_table(encoded)[1]
         self.assertIn('A' * 128, decoded)
+
+    def test_timestamp_with_dst(self):
+        # this test assumes the system is set up using a northern hemisphere
+        # timesone with DST (America/New_York as per github CI is fine)
+        data = datetime.datetime(2006, 5, 21, 16, 30, 10)
+        encoded = encode.timestamp(data)
+        decoded = decode.timestamp(encoded)[1]
+        self.assertEqual(decoded, data)

--- a/tests/test_frame_unmarshaling.py
+++ b/tests/test_frame_unmarshaling.py
@@ -336,7 +336,7 @@ class DemarshalingTests(unittest.TestCase):
             'reply_to': 'unmarshaling_tests',
             'expiration': '1345274026',
             'message_id': '746a1902-39dc-47cf-9471-9feecda35660',
-            'timestamp': datetime.datetime(2012, 10, 2, 10, 51, 3),
+            'timestamp': datetime.datetime(2012, 10, 2, 9, 51, 3),
             'message_type': 'unittest',
             'user_id': 'pika',
             'app_id': 'frame_unmarshaling_tests',


### PR DESCRIPTION
While upgrading [aioamqp](https://github.com/Polyconseil/aioamqp/) to pamqp 3, I stumbled across timestamp properties that were off by an hour. So I went digging and found a regression in 837753e15ff7b3d54c02156aa5fac0183d9dcec3, specifically in [`decode.py`](https://github.com/gmr/pamqp/commit/837753e15ff7b3d54c02156aa5fac0183d9dcec3#diff-e33a80327eb00ab6e10ecdebfcd7a35ecfff51a6dd2c24f3ee250afb1fb6ac38R226-R227).

AFAICT (TZ and DST stuff hurts my brain), DST information is lost between `time.gmtime()` and `time.mktime()` so timestamps that point to times where DST is used (e.g. summer months in America/New_York) will lose said DST information and be an hour off. Most of the test suite uses 2006-11-21 as test data but that doesn't use DST in the northern hemisphere so the bug is sneakily avoided.

So the purpose of this PR is to make sure all datetime objects in and out of the timestamp property are naive objects representing UTC, as I understood that that was the intent of the code. (left to do: docstrings should probably reflect that)

My suggestion though (and this PR does **not** do it, but I'll gladly rework it if you agree) would be to standardize on TZ-aware objects instead. They are unambiguous and much safer to work with. I also see very little value in supporting `time.struct_time` objects (they suffer from the same ambiguity as naive datetime objects) so I would also remove that.

In aioamqp, I will probably provide an optional monkeypatch context manager that "fixes" pamqp to only deal with TZ-aware objects.

Cheers,

Rémi