### PR TITLE
Fix UnicodeDecodeError of `long_string` headers

### DIFF
--- a/pamqp/common.py
+++ b/pamqp/common.py
@@ -36,7 +36,7 @@ Guidelines for implementers:
 
 """
 
-FieldValue = typing.Union[bool, bytearray, decimal.Decimal, FieldArray,
+FieldValue = typing.Union[bool, bytes, bytearray, decimal.Decimal, FieldArray,
                           FieldTable, float, int, None, str, datetime.datetime]
 """Defines valid field values for a :const:`FieldTable` and a
 :const:`FieldValue`

--- a/pamqp/decode.py
+++ b/pamqp/decode.py
@@ -163,7 +163,7 @@ def long_long_int(value: bytes) -> typing.Tuple[int, int]:
         raise ValueError('Could not unpack long-long integer value')
 
 
-def long_str(value: bytes) -> typing.Tuple[int, str]:
+def long_str(value: bytes) -> typing.Tuple[int, typing.Union[str, bytes]]:
     """Decode a string value, returning bytes consumed and the value.
 
     :param value: The binary value to decode
@@ -176,6 +176,8 @@ def long_str(value: bytes) -> typing.Tuple[int, str]:
         return length + 4, value[4:length + 4].decode('utf-8')
     except TypeError:
         raise ValueError('Could not unpack long string value')
+    except UnicodeDecodeError:
+        return length + 4, value[4:length + 4]
 
 
 def octet(value: bytes) -> typing.Tuple[int, int]:

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -174,10 +174,12 @@ class CodecDecodeTests(unittest.TestCase):
         self.assertIsInstance(decode.long_str(value)[1], str)
 
     def test_decode_long_str_data_type_unicode(self):
-        self.assertIsInstance(
-            decode.long_str(b'\x00\x00\x00\x0c\xd8\xa7'
-                            b'\xd8\xae\xd8\xaa\xd8\xa8'
-                            b'\xd8\xa7\xd8\xb1')[1], str)
+        value = b'\0\0\0\x0c\xd8\xa7\xd8\xae\xd8\xaa\xd8\xa8\xd8\xa7\xd8\xb1'
+        self.assertIsInstance(decode.long_str(value)[1], str)
+
+    def test_decode_long_str_data_type_non_unicode(self):
+        value = b'\x00\x00\x00\x01\xff'
+        self.assertIsInstance(decode.long_str(value)[1], bytes)
 
     def test_decode_long_str_invalid_value(self):
         self.assertRaises(ValueError, decode.long_str, None)


### PR DESCRIPTION
First of all, I do understand that pamqp is a AMQP **0.9.1** parser. But due to rabbitmq accepting AMQP 1.0 clients via plugin, and python being the only language in the whole world making a stupid distinction between `str` and `bytes`, the problem is relevant to pamqp.

AMQP 1.0 clients send headers called `x-amqp-properties` and `x-amqp-app-properties`, which cannot be decoded as utf-8. Technically, any client can do that - AMQP 0.9.1 spec paragraph 4.2.5.3 says "Long strings can contain any data", after all - but ~sane people~ most won't.

These headers look like `b'\\x00St\\xc1a\\x08\\xa1\\tcfx-topic\\xa1\\x03CFX\\xa1\\x0bcfx-message\\xa1\\rCFX.Heartbeat\\xa1\\ncfx-handle\\xa1\\x19[REDACTED]-----[REDACTED]\\xa1\\ncfx-target@'`

`pyamqp` works around the issue [by catching the dreaded
`UnicodeDecodeError`](https://github.com/celery/py-amqp/blob/master/amqp/serialization.py#L40-L43). This PR does the same, and adds tests.

There's another interoperability issue - AMQP 1.0 timestamp is in _milli_seconds, and receiving AMQP-1.0 message over AMQP-0.9.1 connection will raise `ValueError('year 53768 is out of range')` - but I guess I'll need to monkeypatch for that. (Ironically, I don't even use that timestamp - but it still throws an exception at me and wastes CPU resources decoding that date..)