### PR TITLE
Add support for white spaces in queue and exchange names

### DIFF
--- a/pamqp/constants.py
+++ b/pamqp/constants.py
@@ -71,8 +71,8 @@ DOMAINS = {
 
 # AMQP domain patterns
 DOMAIN_REGEX = {
-    'exchange-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/]*$'),
-    'queue-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/]*$')
+    'exchange-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/\s]*$'),
+    'queue-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/\s]*$')
 }
 
 # Other constants


### PR DESCRIPTION
White spaces in queue and exchange names in RabbitMQ are valid.

Fixes #47