### PR TITLE
Remove `internal must be false` check to support RabbitMQ Tracing

### DIFF
--- a/pamqp/commands.py
+++ b/pamqp/commands.py
@@ -865,8 +865,6 @@ class Exchange:
             if self.exchange is not None and not constants.DOMAIN_REGEX[
                     'exchange-name'].fullmatch(self.exchange):
                 raise ValueError('Invalid value for exchange')
-            if self.internal is not None and self.internal is not False:
-                raise ValueError('internal must be False')
 
     class DeclareOk(base.Frame):
         """Confirm exchange declaration


### PR DESCRIPTION
RabbitMQ has this special queue called `amq.rabbitmq.trace` which has these parameters: `auto_delete=False, type=ExchangeType.TOPIC, durable=True, internal=True`

However initializing internal to False, was throwing error, removing the check, the tracing is working as expected

`