### PR TITLE
Allow + in queue and exchange names

### DIFF
--- a/pamqp/constants.py
+++ b/pamqp/constants.py
@@ -71,8 +71,8 @@ DOMAINS = {
 
 # AMQP domain patterns
 DOMAIN_REGEX = {
-    'exchange-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/ ]*$'),
-    'queue-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/ ]*$')
+    'exchange-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/+ ]*$'),
+    'queue-name': re.compile(r'^[a-zA-Z0-9-_.:@#,/+ ]*$')
 }
 
 # Other constants


### PR DESCRIPTION
Similar to #47. Pika currently allows `+` and RabbitMQ doesn't have any issue with it