### PR TITLE
Fix FieldValue typing

### DIFF
--- a/pamqp/common.py
+++ b/pamqp/common.py
@@ -36,14 +36,15 @@ Guidelines for implementers:
 
 """
 
-FieldValue = typing.Union[bool, bytes, bytearray, decimal.Decimal, FieldArray,
-                          FieldTable, float, int, None, str, datetime.datetime]
+FieldValue = typing.Union[bool, bytes, bytearray, decimal.Decimal,
+                          "FieldArray", "FieldTable", float, int, None, str,
+                          datetime.datetime]
 """Defines valid field values for a :const:`FieldTable` and a
 :const:`FieldValue`
 
 """
 
-Arguments = typing.Optional[FieldTable]
+Arguments = typing.Optional["FieldTable"]
 """Defines an AMQP method arguments argument data type"""
 
 


### PR DESCRIPTION
We encounter an issue with pyright when working with `aio-pika` which uses this library under the hood. The root cause is that `FieldTable` and `FieldValue` are mutually recursive and `FieldValue` doesn't use a string to delay evaluation of the `FieldTable` type.