### PR TITLE
Fix encoding of negative byte-range integers in field tables

### DIFF
--- a/pamqp/encode.py
+++ b/pamqp/encode.py
@@ -312,7 +312,7 @@ def table_integer(value: int) -> bytes:
     if DEPRECATED_RABBITMQ_SUPPORT:
         return _deprecated_table_integer(value)
     if -128 <= value <= 127:
-        return b'b' + octet(value)
+        return b'b' + common.Struct.short_short_int.pack(value)
     elif -32768 <= value <= 32767:
         return b's' + short_int(value)
     elif 0 <= value <= 65535:
@@ -336,7 +336,7 @@ def _deprecated_table_integer(value: int) -> bytes:
 
     """
     if -128 <= value <= 127:
-        return b'b' + octet(value)
+        return b'b' + common.Struct.short_short_int.pack(value)
     elif -32768 <= value <= 32767:
         return b's' + short_int(value)
     elif -2147483648 <= value <= 2147483647:

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -272,6 +272,12 @@ class MarshalingTests(unittest.TestCase):
         ]
         self.assertEqual(encode.by_type(data, 'field_array'), expectation)
 
+    def test_encode_table_with_negative_integer(self):
+        data = {'x-priority': -1}
+        result = encode.field_table(data)
+        self.assertIn(b'x-priority', result)
+        self.assertIn(b'b\xff', result)
+
     def test_encode_by_type_byte_array(self):
         self.assertEqual(
             encode.by_type(bytearray((65, 66, 67)), 'bytearray'),
@@ -403,6 +409,8 @@ class EncodeTableIntegerTestCase(unittest.TestCase):
     def test_table_integer(self):
         tests = {
             'short-short': (32, b'b '),
+            'short-short-negative': (-1, b'b\xff'),
+            'short-short-min': (-128, b'b\x80'),
             'short': (1024, b's\x04\x00'),
             'short-negative': (-1024, b's\xfc\x00'),
             'short-unsigned': (32768, b'u\x80\x00'),
@@ -428,6 +436,8 @@ class EncodeTableIntegerTestCase(unittest.TestCase):
         self.assertTrue(encode.DEPRECATED_RABBITMQ_SUPPORT)
         tests = {
             'short-short': (32, b'b '),
+            'short-short-negative': (-1, b'b\xff'),
+            'short-short-min': (-128, b'b\x80'),
             'short': (1024, b's\x04\x00'),
             'short-negative': (-1024, b's\xfc\x00'),
             'long': (65536, b'I\x00\x01\x00\x00'),


### PR DESCRIPTION
## Summary
- `table_integer` routed values in `-128..127` to `octet()` which uses unsigned byte format (`struct 'B'`), causing `struct.error` for negative values
- Use the signed byte struct (`short_short_int`, `>b`) instead, matching the AMQP `b` type tag semantics
- Fixes both the standard and deprecated RabbitMQ code paths

This affects `x-priority`, `x-delivery-limit`, and any other table argument using small negative integers.

Fixes #45

## Test plan
- [x] Added negative byte-range test cases (`-1`, `-128`) to both standard and deprecated `table_integer` tests
- [x] Added integration test encoding a field table with `{'x-priority': -1}`
- [x] All 850 tests pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed encoding of small negative integers in AMQP table operations. Negative values in the range [-128, 127] are now correctly encoded, improving reliability when working with priority fields and similar attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->