### PR TITLE
Fix infinite loop decoding malformed field arrays/tables (#63)

### DIFF
--- a/pamqp/decode.py
+++ b/pamqp/decode.py
@@ -326,6 +326,8 @@ def field_array(value: bytes) -> tuple[int, common.FieldArray]:
         offset = 4
         data = []
         field_array_end = offset + length
+        if field_array_end > len(value):
+            raise ValueError('Field array length exceeds available data')
         while offset < field_array_end:
             consumed, result = embedded_value(value[offset:])
             offset += consumed
@@ -348,9 +350,13 @@ def field_table(value: bytes) -> tuple[int, common.FieldTable]:
         offset = 4
         data = {}
         field_table_end = offset + length
+        if field_table_end > len(value):
+            raise ValueError('Field table length exceeds available data')
         while offset < field_table_end:
             key_length = common.Struct.byte.unpack_from(value, offset)[0]
             offset += 1
+            if offset + key_length > field_table_end:
+                raise ValueError('Field table key length exceeds data')
             key = value[offset : offset + key_length].decode('utf-8')
             offset += key_length
             consumed, result = embedded_value(value[offset:])

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -316,6 +316,21 @@ class CodecDecodeTests(unittest.TestCase):
             else:
                 self.assertEqual(value[key], self.FIELD_TBL_VALUE[key])
 
+    def test_decode_field_array_length_exceeds_data(self):
+        # Declares 10 bytes of content but only supplies a 2-byte element
+        payload = struct.pack('>I', 10) + b'b\x01'
+        self.assertRaises(ValueError, decode.field_array, payload)
+
+    def test_decode_field_table_length_exceeds_data(self):
+        # Declares 10 bytes of content but supplies fewer
+        payload = struct.pack('>I', 10) + b'\x03key'
+        self.assertRaises(ValueError, decode.field_table, payload)
+
+    def test_decode_field_table_key_length_exceeds_data(self):
+        # Key claims 20 bytes but the table only holds a few
+        payload = struct.pack('>I', 4) + b'\x14key'
+        self.assertRaises(ValueError, decode.field_table, payload)
+
     def test_decode_by_type_bit_bytes_consumed(self):
         self.assertEqual(decode.by_type(b'\xff', 'bit', 4)[0], 0)
 


### PR DESCRIPTION
## Summary

Fixes #63 — an infinite loop (DoS) when decoding malformed field arrays and tables from untrusted network bytes.

## Problem

`decode.field_array` and `decode.field_table` looped `while offset < declared_end`, advancing `offset` only by what `embedded_value()` reported consuming. When a malformed or truncated frame's declared length pointed past the real buffer, `embedded_value()` was handed an empty slice, returned `(0, None)`, and `offset` stopped advancing — hanging the decode thread indefinitely. Because pamqp decodes bytes received from the network, a peer could send a crafted frame to hang the decoder.

Reproduction from the issue:

```python
import struct
from pamqp import decode

payload = struct.pack('>I', 10) + b'b\x01'
decode.field_array(payload)   # previously hung forever
```

## Solution

Bound both loops against the actual buffer:

- **`field_array`**: raise `ValueError` when the declared content length exceeds the available data.
- **`field_table`**: same end-bound check, plus validate the per-entry key length against the table bounds before slicing.

Once the loop end is bounded by `len(value)`, `offset` is always `< len(value)` inside the loop, so `embedded_value()` always receives a non-empty slice and consumes at least one byte — guaranteeing termination. The crafted payloads now raise `ValueError` instead of hanging.

## Testing

- Added three regression tests (array-length-exceeds-data, table-length-exceeds-data, table-key-length-exceeds-data).
- Full suite passes (853 tests); `pamqp/decode.py` retains 100% coverage; ruff/mypy/basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AMQP decoding safety by validating that encoded array and table lengths fit within the available data.
  * Added checks to reject truncated payloads and oversized key lengths with clear errors.
* **Tests**
  * Expanded decoding tests to cover invalid length cases and confirm errors are raised for malformed input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->