### PR TITLE
Fix infinite loop in ContentHeader._get_flags on malformed flags (#64)

### DIFF
--- a/pamqp/header.py
+++ b/pamqp/header.py
@@ -124,10 +124,13 @@ class ContentHeader:
         """
         bytes_consumed, flags, flagword_index = 0, 0, 0
         while True:
+            if len(data) < 2:
+                raise ValueError('Content header flags are truncated')
             consumed, partial_flags = decode.short_int(data)
             bytes_consumed += consumed
             flags |= partial_flags << (flagword_index * 16)
-            if not partial_flags & 1:  # pragma: nocover
+            if not partial_flags & 1:
                 break
-            flagword_index += 1  # pragma: nocover
+            data = data[consumed:]
+            flagword_index += 1
         return bytes_consumed, flags

--- a/pamqp/header.py
+++ b/pamqp/header.py
@@ -121,6 +121,8 @@ class ContentHeader:
         """Decode the flags from the data returning the bytes consumed and
         flags.
 
+        :raises: ValueError if the content header flags are truncated
+
         """
         bytes_consumed, flags, flagword_index = 0, 0, 0
         while True:

--- a/tests/test_frame_unmarshaling_errors.py
+++ b/tests/test_frame_unmarshaling_errors.py
@@ -1,7 +1,7 @@
 import struct
 import unittest
 
-from pamqp import constants, exceptions, frame
+from pamqp import constants, exceptions, frame, header
 
 
 class TestCase(unittest.TestCase):
@@ -123,3 +123,9 @@ class TestCase(unittest.TestCase):
             self.assertTrue(
                 str(err).startswith('Could not unmarshal ContentHeader frame:')
             )
+
+    def test_content_header_truncated_flag_continuation(self):
+        # A single flag word with the continuation bit set but no further
+        # data must raise rather than loop forever re-reading the same bytes
+        data = struct.pack('>HHQ', 60, 0, 0) + struct.pack('>H', 1)
+        self.assertRaises(ValueError, header.ContentHeader().unmarshal, data)


### PR DESCRIPTION
## Summary

Fixes #64 — an infinite loop (DoS) when unmarshaling a content-header frame with a malformed flag continuation bit.

## Problem

`ContentHeader._get_flags` reads flag words in a loop but called `decode.short_int(data)` on the **same** `data` slice every iteration — it never advanced past the flag word it just consumed, and it never checked the buffer bounds. When a flag word has the continuation bit set (`partial_flags & 1`), the loop re-reads the identical two bytes forever. Because content-header frames are parsed from network input, a peer could send a header whose first flag word has the low bit set to hang the decoder.

Reproduction from the issue:

```python
import struct
from pamqp.header import ContentHeader

data = struct.pack('>HHQ', 60, 0, 0) + struct.pack('>H', 1)
ContentHeader().unmarshal(data)   # previously hung forever
```

## Solution

Advance `data` past each consumed flag word and raise `ValueError` when fewer than two bytes remain, so a set continuation bit with no further data terminates instead of spinning. The crafted payload now raises `ValueError` instead of hanging.

Removing the hang also makes the loop's `break` branch reachable under coverage, so the stale `# pragma: nocover` markers on the loop body are removed.

## Testing

- Added a regression test (`test_content_header_truncated_flag_continuation`) exercising the exact repro.
- Full suite passes (854 tests); `pamqp/header.py` retains 100% coverage; ruff/mypy/basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of truncated content header data so malformed input now raises a clear error instead of failing unexpectedly.
  * Fixed frame unmarshalling behavior for incomplete flag data, preventing incorrect re-reading and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->