### PR TITLE
Fix signed-decimal decode and struct.error contract (#65, #68)

### DIFF
--- a/pamqp/decode.py
+++ b/pamqp/decode.py
@@ -6,6 +6,7 @@ Functions for decoding data of various types including field tables and arrays
 import collections.abc
 import datetime
 import decimal as _decimal
+import struct
 
 from pamqp import common
 
@@ -39,10 +40,10 @@ def bit(value: bytes, position: int) -> tuple[int, bool]:
     :raises ValueError: when the binary data can not be unpacked
 
     """
-    bit_buffer = common.Struct.byte.unpack_from(value)[0]
     try:
+        bit_buffer = common.Struct.byte.unpack_from(value)[0]
         return 0, (bit_buffer & (1 << position)) != 0
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack bit value') from err
 
 
@@ -56,7 +57,7 @@ def boolean(value: bytes) -> tuple[int, bool]:
     """
     try:
         return 1, bool(common.Struct.byte.unpack_from(value[0:1])[0])
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack boolean value') from err
 
 
@@ -71,7 +72,7 @@ def byte_array(value: bytes) -> tuple[int, bytearray]:
     try:
         length = common.Struct.integer.unpack(value[0:4])[0]
         return length + 4, bytearray(value[4 : length + 4])
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack byte array value') from err
 
 
@@ -85,9 +86,9 @@ def decimal(value: bytes) -> tuple[int, _decimal.Decimal]:
     """
     try:
         decimals = common.Struct.byte.unpack(value[0:1])[0]
-        raw = common.Struct.integer.unpack(value[1:5])[0]
+        raw = common.Struct.uint.unpack(value[1:5])[0]
         return 5, _decimal.Decimal(raw) * (_decimal.Decimal(10) ** -decimals)
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack decimal value') from err
 
 
@@ -101,7 +102,7 @@ def double(value: bytes) -> tuple[int, float]:
     """
     try:
         return 8, common.Struct.double.unpack_from(value)[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack double value') from err
 
 
@@ -115,7 +116,7 @@ def floating_point(value: bytes) -> tuple[int, float]:
     """
     try:
         return 4, common.Struct.float.unpack_from(value)[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack floating point value') from err
 
 
@@ -129,7 +130,7 @@ def long_int(value: bytes) -> tuple[int, int]:
     """
     try:
         return 4, common.Struct.long.unpack(value[0:4])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack long integer value') from err
 
 
@@ -144,7 +145,7 @@ def long_uint(value: bytes) -> tuple[int, int]:
     """
     try:
         return 4, common.Struct.ulong.unpack(value[0:4])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError(
             'Could not unpack unsigned long integer value'
         ) from err
@@ -161,7 +162,7 @@ def long_long_int(value: bytes) -> tuple[int, int]:
     """
     try:
         return 8, common.Struct.long_long_int.unpack(value[0:8])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack long-long integer value') from err
 
 
@@ -175,7 +176,7 @@ def long_str(value: bytes) -> tuple[int, str | bytes]:
     """
     try:
         length = common.Struct.integer.unpack(value[0:4])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack long string value') from err
     try:
         return length + 4, value[4 : length + 4].decode('utf-8')
@@ -193,7 +194,7 @@ def octet(value: bytes) -> tuple[int, int]:
     """
     try:
         return 1, common.Struct.byte.unpack(value[0:1])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack octet value') from err
 
 
@@ -207,7 +208,7 @@ def short_int(value: bytes) -> tuple[int, int]:
     """
     try:
         return 2, common.Struct.short.unpack_from(value[0:2])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack short integer value') from err
 
 
@@ -222,7 +223,7 @@ def short_uint(value: bytes) -> tuple[int, int]:
     """
     try:
         return 2, common.Struct.ushort.unpack_from(value[0:2])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError(
             'Could not unpack unsigned short integer value'
         ) from err
@@ -239,7 +240,7 @@ def short_short_int(value: bytes) -> tuple[int, int]:
     """
     try:
         return 1, common.Struct.short_short_int.unpack_from(value[0:1])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack short-short integer value') from err
 
 
@@ -254,7 +255,7 @@ def short_short_uint(value: bytes) -> tuple[int, int]:
     """
     try:
         return 1, common.Struct.short_short_uint.unpack_from(value[0:1])[0]
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError(
             'Could not unpack unsigned short-short integer value'
         ) from err
@@ -271,7 +272,7 @@ def short_str(value: bytes) -> tuple[int, str]:
     try:
         length = common.Struct.byte.unpack(value[0:1])[0]
         return length + 1, value[1 : length + 1].decode('utf-8')
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack short string value') from err
 
 
@@ -292,7 +293,7 @@ def timestamp(value: bytes) -> tuple[int, datetime.datetime]:
             ts_value /= 1000.0
 
         return 8, datetime.datetime.fromtimestamp(ts_value, tz=datetime.UTC)
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack timestamp value') from err
 
 
@@ -333,7 +334,7 @@ def field_array(value: bytes) -> tuple[int, common.FieldArray]:
             offset += consumed
             data.append(result)
         return offset, data
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack data') from err
 
 
@@ -363,7 +364,7 @@ def field_table(value: bytes) -> tuple[int, common.FieldTable]:
             offset += consumed
             data[key] = result
         return field_table_end, data
-    except TypeError as err:
+    except (struct.error, TypeError) as err:
         raise ValueError('Could not unpack data') from err
 
 

--- a/pamqp/frame.py
+++ b/pamqp/frame.py
@@ -178,7 +178,7 @@ def _unmarshal_method_frame(frame_data: bytes) -> base.Frame:
         ) from err
     try:
         method.unmarshal(frame_data[bytes_used:])
-    except struct.error as error:
+    except (struct.error, ValueError) as error:
         raise exceptions.UnmarshalingException(method, error) from error
     return method
 
@@ -192,7 +192,7 @@ def _unmarshal_header_frame(frame_data: bytes) -> header.ContentHeader:
     content_header = header.ContentHeader()
     try:
         content_header.unmarshal(frame_data)
-    except struct.error as error:
+    except (struct.error, ValueError) as error:
         raise exceptions.UnmarshalingException(
             'ContentHeader', error
         ) from error

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -111,6 +111,10 @@ class CodecDecodeTests(unittest.TestCase):
     def test_decode_decimal_invalid_value(self):
         self.assertRaises(ValueError, decode.decimal, False)
 
+    def test_decode_decimal_negative_value(self):
+        value = b'\x01\xff\xff\xff\xf1'
+        self.assertEqual(decode.decimal(value)[1], decimal.Decimal('-1.5'))
+
     def test_decode_double_value(self):
         value = b'@\t!\xf9\xf0\x1b\x86n'
         self.assertEqual(round(decode.double(value)[1], 5), round(3.14159, 5))
@@ -799,3 +803,24 @@ class CodecDecodeTests(unittest.TestCase):
         dt = datetime.datetime(2107, 1, 1, 0, 0, tzinfo=datetime.UTC)
         large_timestamp_bytes = struct.pack('>Q', int(dt.timestamp() * 1000))
         self.assertEqual(decode.timestamp(large_timestamp_bytes)[1], dt)
+
+    def test_decode_truncated_raises_value_error(self):
+        for name, decoder in (
+            ('bit', lambda v: decode.bit(v, 0)),
+            ('boolean', decode.boolean),
+            ('byte_array', decode.byte_array),
+            ('decimal', decode.decimal),
+            ('double', decode.double),
+            ('floating_point', decode.floating_point),
+            ('long_int', decode.long_int),
+            ('long_uint', decode.long_uint),
+            ('long_long_int', decode.long_long_int),
+            ('octet', decode.octet),
+            ('short_int', decode.short_int),
+            ('short_uint', decode.short_uint),
+            ('short_short_int', decode.short_short_int),
+            ('short_short_uint', decode.short_short_uint),
+            ('timestamp', decode.timestamp),
+        ):
+            with self.subTest(decoder=name):
+                self.assertRaises(ValueError, decoder, b'')

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,10 +1,17 @@
 import datetime
+import decimal
 import unittest
 
 from pamqp import decode, encode
 
 
 class EncodeDecodeTests(unittest.TestCase):
+    def test_encode_decode_negative_decimal(self):
+        data = decimal.Decimal('-1.5')
+        encoded = encode.decimal(data)
+        decoded = decode.decimal(encoded)[1]
+        self.assertEqual(decoded, data)
+
     def test_encode_decode_field_table_long_keys(self):
         """Encoding and decoding a field_table with too long keys."""
         # second key is 126 A's + \N{PILE OF POO}


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in `pamqp/decode.py` around signed decimals and the documented exception contract.

## Problem

- **#65** — `decode.decimal` unpacked the mantissa with `common.Struct.integer` (`>I`, unsigned) while `encode.decimal` packs it signed (`>Bi`). Any negative decimal decoded as a large positive number.
- **#68** — Every decoder documents `:raises ValueError:` and wraps its unpack in `except TypeError`, but `struct.Struct.unpack`/`unpack_from` raise `struct.error` (not a `TypeError` subclass) on truncated input. The `except TypeError` clauses were dead code and a `struct.error` leaked to callers, breaking the documented contract for partial/malformed reads.

## Solution

- `decode.decimal` now uses `common.Struct.uint` (`>i`, signed), so negative decimals round-trip correctly.
- All decode helpers catch `(struct.error, TypeError)` and re-raise as the documented `ValueError`; `bit()`'s `unpack_from` moved inside its `try`.
- `frame.py`: broadened the two `unmarshal` catches to `(struct.error, ValueError)` so the now-`ValueError`-raising decoders still surface as the documented `UnmarshalingException` (preserves `test_invalid_method_frame_content`).
- Added tests: negative-decimal round-trip and truncated-input `ValueError` across representative decoders.

100% coverage retained; all tests and pre-commit pass.

Closes #65
Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for decoding truncated or malformed values, returning clearer value errors instead of low-level unpacking errors.
  * Fixed decimal decoding so negative decimal values are handled correctly.
  * Broadened frame parsing to surface decoding issues as consistent unmarshaling errors.

* **Tests**
  * Added coverage for negative decimal round-tripping.
  * Added checks that truncated input raises value errors across multiple decoders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->