### PR TITLE
Fix decimal/string encoding validation (#66, #69, #70)

### DIFF
--- a/pamqp/encode.py
+++ b/pamqp/encode.py
@@ -93,13 +93,20 @@ def decimal(value: _decimal.Decimal) -> bytes:
     """
     if not isinstance(value, _decimal.Decimal):
         raise TypeError(f'decimal.Decimal required, received {type(value)}')
-    tmp = str(value)
-    if '.' in tmp:
-        decimals = len(tmp.split('.')[-1])
-        value = value.normalize()
-        raw = int(value * (_decimal.Decimal(10) ** decimals))
-        return struct.pack('>Bi', decimals, raw)
-    return struct.pack('>Bi', 0, int(value))
+    exponent = value.as_tuple().exponent
+    if not isinstance(exponent, int):  # NaN, Infinity, sNaN
+        raise TypeError(f'Cannot encode {value} as a decimal')
+    elif exponent > 0:  # scale a positive exponent up into the mantissa
+        scale = 0
+        mantissa = int(value)
+    else:  # value == mantissa * 10 ** -scale
+        scale = -exponent
+        mantissa = int(value.scaleb(scale))
+    if not (0 <= scale <= 255):
+        raise TypeError('Decimal scale range: 0 to 255')
+    elif not (-2147483648 <= mantissa <= 2147483647):
+        raise TypeError('Decimal mantissa range: -2147483648 to 2147483647')
+    return struct.pack('>Bi', scale, mantissa)
 
 
 def double(value: float) -> bytes:
@@ -207,7 +214,7 @@ def short_int(value: int) -> bytes:
     if not isinstance(value, int):
         raise TypeError(f'int required, received {type(value)}')
     elif not (-32768 <= value <= 32767):
-        raise TypeError('Short integer range: -32678 to 32767')
+        raise TypeError('Short integer range: -32768 to 32767')
     return common.Struct.short.pack(value)
 
 
@@ -288,9 +295,11 @@ def field_table(value: common.FieldTable) -> bytes:
         raise TypeError(f'dict required, received {type(value)}')
     data = []
     for key, item in sorted(value.items()):
-        if len(key) > 128:  # field names have 128 char max
+        encoded_key = key.encode('utf-8')
+        if len(encoded_key) > 128:  # field names have a 128 byte max
             LOGGER.warning('Truncating key %s to 128 bytes', key)
-            key = key[0:128]
+            # ``ignore`` drops a multi-byte character split at the boundary
+            key = encoded_key[0:128].decode('utf-8', 'ignore')
         data.append(short_string(key))
         try:
             data.append(encode_table_value(item))
@@ -355,6 +364,9 @@ def _string(encoder: struct.Struct, value: str) -> bytes:
     if not isinstance(value, str):
         raise TypeError(f'str required, received {type(value)}')
     temp = value.encode('utf-8')
+    max_length = 255 if encoder is common.Struct.byte else 4294967295
+    if len(temp) > max_length:
+        raise TypeError(f'string exceeds maximum length of {max_length} bytes')
     return encoder.pack(len(temp)) + temp
 
 

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 import unittest
 
 from pamqp import decode, encode
@@ -15,6 +16,28 @@ class EncodeDecodeTests(unittest.TestCase):
         encoded = encode.field_table(data)
         decoded = decode.field_table(encoded)[1]
         self.assertIn('A' * 128, decoded)
+
+    def test_encode_decode_field_table_multibyte_key(self):
+        """A multibyte key over 128 bytes must not raise struct.error."""
+        # 128 \N{PILE OF POO} chars encode to 512 bytes
+        key = '\U0001f4a9' * 128
+        encoded = encode.field_table({key: 1})
+        decoded = decode.field_table(encoded)[1]
+        self.assertEqual(list(decoded.values()), [1])
+        # the truncated key must round-trip cleanly (no split characters)
+        (decoded_key,) = decoded
+        self.assertTrue(key.startswith(decoded_key))
+        self.assertLessEqual(len(decoded_key.encode('utf-8')), 128)
+
+    def test_encode_decode_decimal_scientific_notation(self):
+        encoded = encode.decimal(decimal.Decimal('1E-10'))
+        decoded = decode.decimal(encoded)[1]
+        self.assertEqual(decoded, decimal.Decimal('1E-10'))
+
+    def test_encode_decode_decimal(self):
+        value = decimal.Decimal('3.14159')
+        decoded = decode.decimal(encode.decimal(value))[1]
+        self.assertEqual(decoded, value)
 
     def test_timestamp_with_dst(self):
         # this test assumes the system is set up using a northern hemisphere

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -36,6 +36,33 @@ class MarshalingTests(unittest.TestCase):
             encode.decimal(decimal.Decimal(314159)), b'\x00\x00\x04\xcb/'
         )
 
+    def test_encode_decimal_scientific_notation(self):
+        self.assertEqual(
+            encode.decimal(decimal.Decimal('1E-10')), b'\n\x00\x00\x00\x01'
+        )
+
+    def test_encode_decimal_negative(self):
+        self.assertEqual(
+            encode.decimal(decimal.Decimal('-1.5')),
+            b'\x01\xff\xff\xff\xf1',
+        )
+
+    def test_encode_decimal_positive_exponent(self):
+        self.assertEqual(
+            encode.decimal(decimal.Decimal('1E2')), b'\x00\x00\x00\x00d'
+        )
+
+    def test_encode_decimal_scale_out_of_range(self):
+        self.assertRaises(TypeError, encode.decimal, decimal.Decimal('1E-300'))
+
+    def test_encode_decimal_mantissa_out_of_range(self):
+        self.assertRaises(
+            TypeError, encode.decimal, decimal.Decimal('9999999999.9')
+        )
+
+    def test_encode_decimal_not_finite(self):
+        self.assertRaises(TypeError, encode.decimal, decimal.Decimal('NaN'))
+
     def test_encode_double_invalid_value(self):
         self.assertRaises(TypeError, encode.double, '1234')
 
@@ -90,6 +117,13 @@ class MarshalingTests(unittest.TestCase):
     def test_encode_short_error(self):
         self.assertRaises(TypeError, encode.short_int, 32768)
 
+    def test_encode_short_error_message(self):
+        with self.assertRaises(TypeError) as ctx:
+            encode.short_int(-32769)
+        self.assertEqual(
+            str(ctx.exception), 'Short integer range: -32768 to 32767'
+        )
+
     def test_encode_short_uint(self):
         self.assertEqual(encode.short_uint(65535), b'\xff\xff')
 
@@ -107,6 +141,13 @@ class MarshalingTests(unittest.TestCase):
 
     def test_encode_short_string_error(self):
         self.assertRaises(TypeError, encode.short_string, 32768)
+
+    def test_encode_short_string_too_long(self):
+        self.assertRaises(TypeError, encode.short_string, 'a' * 256)
+
+    def test_encode_short_string_too_long_utf8_bytes(self):
+        # 128 multi-byte chars encode to more than 255 bytes
+        self.assertRaises(TypeError, encode.short_string, '🐰' * 128)
 
     def test_encode_short_string_utf8_python3(self):
         self.assertEqual(encode.short_string('🐰'), b'\x04\xf0\x9f\x90\xb0')


### PR DESCRIPTION
## Summary

Fixes silent data loss and cryptic `struct.error` failures in `pamqp/encode.py`, plus a range-message typo.

## Problem

- **#66** — `encode.decimal` decided scale by looking for a literal `'.'` in `str(value)`. Decimals in exponent form (e.g. `Decimal('1E-10')`, routinely produced by `Decimal` arithmetic) contain no `'.'`, so scale was encoded as 0 and the fractional value silently truncated to 0.
- **#69** — `_string` did not validate encoded UTF-8 byte length, so over-length short/long strings failed deep inside `struct`. `field_table` truncated keys by *characters* (`key[0:128]`) while logging "128 bytes"; multibyte keys could still exceed the 255-byte short-string prefix and crash.
- **#70 (typo)** — `short_int` range message read `-32678` instead of `-32768`.

## Solution

- `encode.decimal` derives scale/mantissa from `value.as_tuple().exponent` (handles exponent- and non-exponent-form identically), guards scale to an octet (0–255) and mantissa to signed 32-bit, and rejects non-finite Decimals — all with clear `TypeError`s. Existing byte outputs are unchanged.
- `_string` validates encoded byte length against the prefix capacity (255 for short, 2^32−1 for long) and raises `TypeError`.
- `field_table` truncates keys by UTF-8 byte length (≤128 bytes, without splitting a multibyte sequence) and the log message is now accurate.
- Fixed the `short_int` message typo.
- Added tests for scientific-notation/negative/positive-exponent decimals, out-of-range and non-finite decimals, over-length strings (by count and by multibyte width), the multibyte-key round-trip, and the corrected message.

100% coverage retained; all tests and pre-commit pass.

Closes #66
Closes #69
Addresses #70 (the `short_int` range-message typo; the 8-bit-field part is handled in the base.py PR)
