### PR TITLE
Fix BasicProperties.__eq__ and 8-bit frame codec (#67, #70)

### DIFF
--- a/pamqp/base.py
+++ b/pamqp/base.py
@@ -95,10 +95,10 @@ class Frame(_AMQData):
                 else:
                     byte = encode.bit(data_value, byte, offset)
                     offset += 1
-                    if offset == 8:  # pragma: nocover
+                    if offset == 8:
                         output.append(encode.octet(byte))
                         processing_bitset = False
-                    continue  # pragma: nocover
+                    continue
             output.append(encode.by_type(data_value, data_type))
         if processing_bitset:
             output.append(encode.octet(byte))
@@ -114,13 +114,10 @@ class Frame(_AMQData):
         offset, processing_bitset = 0, False
         for argument in self.__slots__:
             data_type = self.amqp_type(argument)
-            if offset == 7 and processing_bitset:  # pragma: nocover
+            if processing_bitset and (data_type != 'bit' or offset == 8):
                 data = data[1:]
-                offset = 0
-            if processing_bitset and data_type != 'bit':
                 offset = 0
                 processing_bitset = False
-                data = data[1:]
             consumed, value = decode.by_type(data, data_type, offset)
             if data_type == 'bit':
                 offset += 1
@@ -150,7 +147,7 @@ class BasicProperties(_AMQData):
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, BasicProperties):
-            raise NotImplementedError
+            return NotImplemented
         return all(
             getattr(self, k, None) == getattr(other, k, None)
             for k in self.__slots__

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1785,9 +1785,15 @@ class MethodAttributeDefaultTests(unittest.TestCase):
             ],
         )
 
-    def test_basic_properties_eq_error(self):
-        with self.assertRaises(NotImplementedError):
-            self.assertEqual(commands.Basic.Properties(), {})
+    def test_basic_properties_eq_non_properties(self):
+        self.assertFalse(commands.Basic.Properties() == 5)
+        self.assertTrue(commands.Basic.Properties() != 5)
+
+    def test_basic_properties_eq_equal(self):
+        self.assertEqual(
+            commands.Basic.Properties(app_id='unittest'),
+            commands.Basic.Properties(app_id='unittest'),
+        )
 
     def test_basic_properties_bad_delivery_mode_error(self):
         with self.assertRaises(ValueError):

--- a/tests/test_frame_marshaling.py
+++ b/tests/test_frame_marshaling.py
@@ -2,7 +2,42 @@ import datetime
 import unittest
 import uuid
 
-from pamqp import body, commands, frame, header, heartbeat
+from pamqp import base, body, commands, frame, header, heartbeat
+
+
+class _EightBitFrame(base.Frame):
+    __slots__ = ['b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7']
+
+    _b0 = 'bit'
+    _b1 = 'bit'
+    _b2 = 'bit'
+    _b3 = 'bit'
+    _b4 = 'bit'
+    _b5 = 'bit'
+    _b6 = 'bit'
+    _b7 = 'bit'
+
+    def __init__(self, *values):
+        for name, value in zip(self.__slots__, values, strict=False):
+            setattr(self, name, value)
+
+
+class _NineBitFrame(base.Frame):
+    __slots__ = ['b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7', 'b8']
+
+    _b0 = 'bit'
+    _b1 = 'bit'
+    _b2 = 'bit'
+    _b3 = 'bit'
+    _b4 = 'bit'
+    _b5 = 'bit'
+    _b6 = 'bit'
+    _b7 = 'bit'
+    _b8 = 'bit'
+
+    def __init__(self, *values):
+        for name, value in zip(self.__slots__, values, strict=False):
+            setattr(self, name, value)
 
 
 class MarshalingTests(unittest.TestCase):
@@ -112,3 +147,27 @@ class MarshalingTests(unittest.TestCase):
     def test_unknown_frame_type(self):
         with self.assertRaises(ValueError):
             frame.marshal(self, 1)
+
+    def test_eight_consecutive_bits_marshal(self):
+        obj = _EightBitFrame(*([True] * 8))
+        self.assertEqual(obj.marshal(), b'\xff')
+
+    def test_eight_consecutive_bits_round_trip(self):
+        values = [True, False, True, False, True, True, False, True]
+        obj = _EightBitFrame(*values)
+        result = _EightBitFrame()
+        result.unmarshal(obj.marshal())
+        self.assertEqual(
+            [getattr(result, name) for name in result.__slots__], values
+        )
+
+    def test_nine_consecutive_bits_round_trip(self):
+        values = [True] * 8 + [True]
+        obj = _NineBitFrame(*values)
+        marshaled = obj.marshal()
+        self.assertEqual(marshaled, b'\xff\x01')
+        result = _NineBitFrame()
+        result.unmarshal(marshaled)
+        self.assertEqual(
+            [getattr(result, name) for name in result.__slots__], values
+        )


### PR DESCRIPTION
## Summary

Fixes the `BasicProperties.__eq__` sentinel and the latent 8+-consecutive-bit marshal/unmarshal round-trip in `pamqp/base.py`.

## Problem

- **#67** — `BasicProperties.__eq__` did `raise NotImplementedError` for non-`BasicProperties` operands. That raises on ordinary comparisons like `props == None` or `props in some_list`. The correct sentinel is the singleton `NotImplemented`, *returned*, which lets Python fall back to identity comparison (yielding `False`).
- **#70 (bit fields)** — `Frame.marshal`/`unmarshal` did not round-trip frames with 8+ consecutive `bit` attributes. `unmarshal` consumed the packed byte at the wrong boundary and errored. Latent today (no standard AMQP 0-9-1 command has 8+ consecutive bits), hence the `# pragma: nocover` markers.

## Solution

- `__eq__` now `return NotImplemented` for mismatched types; equal `Properties` still compare equal.
- `Frame.unmarshal` consumes the packed byte after all 8 bits are read (or when a non-bit follows), via a single combined guard, so 8- and 9-bit frames round-trip. `marshal` was already correct; removed the now-covered pragmas.
- Added tests: `__eq__` against a non-`BasicProperties` (False / `!=` True) and equal-Properties; synthetic 8-bit (`b'\xff'`) and 9-bit (two-byte) frame round-trips. Existing real-command frames (e.g. `Basic.Consume`) still marshal/unmarshal correctly.

100% coverage retained; all tests and pre-commit pass.

Closes #67
Addresses #70 (the 8-consecutive-bit marshal/unmarshal fix; the `short_int` typo is handled in the encode.py PR)
